### PR TITLE
feat: add support for custom TIP

### DIFF
--- a/sekoia.io/README/inputs.conf.spec
+++ b/sekoia.io/README/inputs.conf.spec
@@ -3,3 +3,4 @@ python.version = python3
 api_key = <value>
 feed_id = <value>
 proxy_url = <value>
+api_root_url = <value>

--- a/sekoia.io/app.manifest
+++ b/sekoia.io/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "sekoia.io",
-      "version": "1.1.2"
+      "version": "1.2.0"
     },
     "author": [
       {

--- a/sekoia.io/app.manifest
+++ b/sekoia.io/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "sekoia.io",
-      "version": "1.2.0"
+      "version": "1.2.1"
     },
     "author": [
       {

--- a/sekoia.io/appserver/static/javascript/views/setup_page.js
+++ b/sekoia.io/appserver/static/javascript/views/setup_page.js
@@ -34,6 +34,7 @@ define(["backbone", "jquery", "splunkjs/splunk"], function (Backbone, jquery, sp
                 jquery("#api_key").val(input["api_key"]);
                 jquery("#feed_id").val(input["feed_id"]);
                 jquery("#proxy_url").val(input["proxy_url"]);
+                jquery("#api_root_url").val(input["api_root_url"]);
             }
 
             Object.keys(this.current_settings["lookups"]).forEach((name) => {
@@ -134,15 +135,16 @@ define(["backbone", "jquery", "splunkjs/splunk"], function (Backbone, jquery, sp
             const feed_settings = {
                 api_key: "<nothing to see here>",
                 feed_id: feed_id,
-                proxy_url: values[2].value.trim(),
+                api_root_url: values[2].value.trim(),
+                proxy_url: values[3].value.trim(),
             };
 
             // Extract Lookups
             const lookups = new Array();
             var i = 0;
 
-            while (i * 3 + 3 < values.length) {
-                const offset = 3 + i * 3;
+            while (i * 3 + 4 < values.length) {
+                const offset = 4 + i * 3;
                 lookups.push({
                     type: values[offset].value.trim(),
                     query: values[offset + 1].value.trim(),

--- a/sekoia.io/appserver/static/javascript/views/setup_page.js
+++ b/sekoia.io/appserver/static/javascript/views/setup_page.js
@@ -126,7 +126,7 @@ define(["backbone", "jquery", "splunkjs/splunk"], function (Backbone, jquery, sp
             
             
             // Extract Feed Settings
-            feed_id = values[1].value.trim();
+            var feed_id = values[1].value.trim();
             if (feed_id == "") {
                 feed_id = "d6092c37-d8d7-45c3-8aff-c4dc26030608";
             }

--- a/sekoia.io/appserver/static/javascript/views/setup_page_template.js
+++ b/sekoia.io/appserver/static/javascript/views/setup_page_template.js
@@ -53,6 +53,14 @@ function get_template() {
                     </p>
 
                     <label>
+                        SEKOIA.IO API URL
+                        <input id="api_root_url" type="text" name="api_root_url" placeholder="https://api.sekoia.io" />
+                    </label>
+                    <p class="hint">
+                        (optional) URL root of your SEKOIA.IO TIP API (e.g. https://api.sekoia.io or https://my.sekoiaio.tip.local/api)
+                    </p>
+
+                    <label>
                         Proxy URL
                         <input id="proxy_url" type="text" name="proxy_url" placeholder="http://[username:password@]host:port" />
                     </label>

--- a/sekoia.io/default/app.conf
+++ b/sekoia.io/default/app.conf
@@ -14,7 +14,7 @@ setup_view = setup
 [launcher]
 author = support@sekoia.io
 description = Search your logs with Indicators of Compromise (IoCs) from SEKOIA.IO.
-version = 1.2.0
+version = 1.2.1
 
 [package]
 check_for_updates = 1

--- a/sekoia.io/default/app.conf
+++ b/sekoia.io/default/app.conf
@@ -14,7 +14,7 @@ setup_view = setup
 [launcher]
 author = support@sekoia.io
 description = Search your logs with Indicators of Compromise (IoCs) from SEKOIA.IO.
-version = 1.1.2
+version = 1.2.0
 
 [package]
 check_for_updates = 1

--- a/sekoia.io/default/data/ui/views/dashboard.xml
+++ b/sekoia.io/default/data/ui/views/dashboard.xml
@@ -106,7 +106,12 @@
         <option name="refresh.display">progressbar</option>
         <drilldown>
           <condition field="matched_ioc">
-            <link target="_blank">https://app.sekoia.io/inthreatv2/objects/$row.indicator_id$</link>
+	    <condition match="$row.server_root_url$ != &quot;&quot;">
+              <link target="_blank">$row.server_root_url$/inthreatv2/objects/$row.indicator_id$</link>
+	    </condition>
+	    <condition match="$row.server_root_url$ == &quot;&quot;">
+              <link target="_blank">https://app.sekoia.io/inthreatv2/objects/$row.indicator_id$</link>
+	    </condition>
           </condition>
         </drilldown>
       </table>


### PR DESCRIPTION
This PR introduces the following changes:
- configuration of the app supports the definition of an optional `api_root_url`
- indicator download leverages the optional `api_root_url` config
- dashboard links to an indicator page inferred from the `api_root_url`