### PR TITLE
fix(sekoia_indicators): sleep in seconds

### DIFF
--- a/sekoia.io/app.manifest
+++ b/sekoia.io/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "sekoia.io",
-      "version": "1.2.1"
+      "version": "1.2.2"
     },
     "author": [
       {

--- a/sekoia.io/bin/sekoia_indicators.py
+++ b/sekoia.io/bin/sekoia_indicators.py
@@ -457,7 +457,7 @@ class SEKOIAIndicators(Script):
                     ew.INFO,
                     "Done fetching indicators of all the SEKOIA.IO inputs, sleeping for 10 minutes.",
                 )
-                time.sleep(10)
+                time.sleep(600)
 
 
 if __name__ == "__main__":

--- a/sekoia.io/default/app.conf
+++ b/sekoia.io/default/app.conf
@@ -14,7 +14,7 @@ setup_view = setup
 [launcher]
 author = support@sekoia.io
 description = Search your logs with Indicators of Compromise (IoCs) from SEKOIA.IO.
-version = 1.2.1
+version = 1.2.2
 
 [package]
 check_for_updates = 1


### PR DESCRIPTION
The sleep between two indicator refresh is too small because of a unit error.