### PR TITLE
Explicitly check api_root_url is https

### DIFF
--- a/sekoia.io/appserver/static/javascript/views/setup_configuration.js
+++ b/sekoia.io/appserver/static/javascript/views/setup_configuration.js
@@ -22,6 +22,16 @@ function promisify(fn) {
   }
 }
 
+async function validate_settings(feed_settings) {
+
+    if (feed_settings.api_root_url) {
+	const u = new URL(feed_settings.api_root_url);
+	if (u.protocol != 'https:') {
+	    throw 'Only secured urls (https) are supported for api_root_url'
+	}
+    }
+}
+
 async function setup_modular_input(splunk_js_sdk_service, properties) {
     await SplunkHelpers.update_configuration_file(
         splunk_js_sdk_service,
@@ -192,5 +202,6 @@ export {
     get_lookup_settings,
     setup_lookups,
     setup_cleanup,
-    setup_api_key
+    setup_api_key,
+    validate_settings
 };

--- a/sekoia.io/appserver/static/javascript/views/setup_page.js
+++ b/sekoia.io/appserver/static/javascript/views/setup_page.js
@@ -178,6 +178,9 @@ define(["backbone", "jquery", "splunkjs/splunk"], function (Backbone, jquery, sp
 
                 let { api_key, feed_settings, lookups } = settings;
 
+		// Validate the settings
+		await Setup.validate_settings(feed_settings);
+
                 // Store api-key in secret storage
                 await Setup.setup_api_key(splunk_js_sdk_service, feed_settings['feed_id'], api_key);
 

--- a/sekoia.io/bin/sekoia_indicators.py
+++ b/sekoia.io/bin/sekoia_indicators.py
@@ -7,6 +7,7 @@ import traceback
 from collections import defaultdict
 from datetime import datetime
 from posixpath import join as urljoin
+from urllib.parse import urlparse
 
 if sys.version_info[0] < 3:
     py_version = "py2"
@@ -380,6 +381,7 @@ class SEKOIAIndicators(Script):
         to check the configuration is valid.
 
         It performs the following checks:
+        - checks the api_root_url starts with https
         - checks it can connects to the feed to retrieve few indicators
         """
 
@@ -387,6 +389,14 @@ class SEKOIAIndicators(Script):
             feed_id = definition.parameters["feed_id"] or DEFAULT_FEED
             api_key = definition.parameters["api_key"]
             api_root_url = definition.parameters.get("api_root_url")
+
+            if api_root_url:
+                # appcheck:
+                # check_for_insecure_http_calls_in_python
+                parsed_url = urlparse(api_root_url)
+                if parsed_url.scheme != 'https':
+                    raise ValueError("Only secured urls (https) are supported for api_root_url")
+
             proxy_url = definition.parameters.get("proxy_url")
             if api_key == MASK:
                 return True


### PR DESCRIPTION
This PR introduces validations to prevent non-https urls for api_root_url on:
- the creation of the modular input 
- the setup configuration page