### PR TITLE
ci: Harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Cooldown applies only to version updates, not security updates
+    cooldown:
+      default-days: 14
+    groups:
+      # Group all version updates into a single PR; security updates remain ungrouped
+      github-actions:
+        applies-to: version-updates
+        patterns: ["*"]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           pwd
           ls -la
-          cd ${GITHUB_WORKSPACE}
+          cd "${GITHUB_WORKSPACE}"
           pip install 'splunk-packaging-toolkit==1.2.4'
           mkdir dist
           slim validate sekoia.io/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,14 @@ on:
       - "master"
 
 
+permissions: {}
+
 jobs:
 
   # Package App
   package:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
     name: Package
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,14 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # semantic-release won't trigger a tagged build if this is not set false
           persist-credentials: false
 
       # Our add-on contains Python code, so we need to install Python in the container
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.9
 
@@ -39,21 +39,21 @@ jobs:
           slim validate sekoia.io/
           slim package sekoia.io/ -o dist
 
-      - uses: splunk/appinspect-cli-action@v2.10
+      - uses: splunk/appinspect-cli-action@91f683fe1b0f591daae0bb11a9f16efef1c82f9a # v2.11.0
         with:
           app_path: 'dist/*.tar.gz'
           result_file: 'dist/appinspect-report.json'
           included_tags: cloud
 
       - name: upload-appinspect-report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
           name: appinspect-report.json
           path: dist/appinspect-report.json
 
       - name: Upload package as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: package-splunkbase
           path: dist/*.tar.gz


### PR DESCRIPTION
## Summary

- Configure Dependabot for GitHub Actions (weekly, 14-day cooldown, grouped version updates)
- Pin actions to commit SHAs (14-day minimum age)
- Least-privilege `permissions` (deny-all at workflow level, minimal job-level grants)
- Fix actionlint findings

Edit: the workflow ran here, all looks alright to me:
https://github.com/SEKOIA-IO/SEKOIA.IO-for-Splunk/actions/runs/23350576781