### PR TITLE
fix/splunk_api_key_role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Replace deprecated "Intelligence Center - Read Only" role by new "Analyst Role" in the app setup page template
+- Replace deprecated "Intelligence Center - Read Only" role with new "Analyst Role" in the app setup page template
 
 ## 2026-05-21 - 1.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 2026-07-08 - 1.5.2
+
+### Fixed
+
+- Replace deprecated "Intelligence Center - Read Only" role by new "Analyst Role" in the app setup page template
+
 ## 2026-05-21 - 1.5.1
 
 ### Added

--- a/sekoia.io/appserver/static/javascript/views/setup_page_template.js
+++ b/sekoia.io/appserver/static/javascript/views/setup_page_template.js
@@ -40,7 +40,7 @@ function get_template() {
                     </label>
                     <p class="hint">
                         API Key generated in SEKOIA.IO's User Center that should be used to access the feed content.
-                        This API Key should have at least the "Intelligence Center - Read Only" role.
+                        This API Key should be configured with at least the permissions corresponding to the "Analyst Role".
                     </p>
 
                     <label>

--- a/sekoia.io/appserver/static/javascript/views/setup_page_template.js
+++ b/sekoia.io/appserver/static/javascript/views/setup_page_template.js
@@ -40,7 +40,7 @@ function get_template() {
                     </label>
                     <p class="hint">
                         API Key generated in SEKOIA.IO's User Center that should be used to access the feed content.
-                        This API Key should be configured with at least the permissions corresponding to the "Analyst Role".
+                        This API Key should be configured with at least the read-only permissions corresponding to the "Analyst Role".
                     </p>
 
                     <label>


### PR DESCRIPTION
## Description

Fixes https://github.com/SekoiaLab/integration/issues/1753

### Fixed

- Replace deprecated "Intelligence Center - Read Only" role by new "Analyst Role" in the app setup page template